### PR TITLE
Fix onboarding modal localStorage with error handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,16 +15,16 @@ import OnboardingModal from './components/OnboardingModal';
 
 function Landing() {
   const [isModalOpen, setModalOpen] = useState(false);
+  const MODAL_KEY = 'onboard_v1';
 
   useEffect(() => {
-    const hasVisited = localStorage.getItem('hasVisited');
-    if (!hasVisited) {
-      setModalOpen(true);
-      localStorage.setItem('hasVisited', 'true');
-    }
+    try {
+      if (!localStorage.getItem(MODAL_KEY)) setModalOpen(true);
+    } catch {}
   }, []);
 
   const handleCloseModal = () => {
+    try { localStorage.setItem(MODAL_KEY, 'true'); } catch {}
     setModalOpen(false);
   };
 


### PR DESCRIPTION
## Purpose
Fix the onboarding modal not appearing in production deployment on Render. The user reported that the modal shows locally but fails to display when deployed, likely due to localStorage access issues in certain environments.

## Code changes
- Added try-catch blocks around localStorage operations to handle potential access errors
- Changed localStorage key from 'hasVisited' to more specific 'onboard_v1' 
- Simplified the modal display logic to only check if the key exists
- Added error handling when setting the localStorage value on modal close
- Moved localStorage key to a constant for better maintainabilityTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 15`

🔗 [Edit in Builder.io](https://builder.io/app/projects/da09819e1eed44a1a5f70e70323fbfce/echo-field)

👀 [Preview Link](https://da09819e1eed44a1a5f70e70323fbfce-echo-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>da09819e1eed44a1a5f70e70323fbfce</projectId>-->
<!--<branchName>echo-field</branchName>-->