### PR TITLE
Show onboarding modal on every page reload

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { Routes, Route, useLocation } from 'react-router-dom';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import Navbar from './sections/Navbar';
 import Hero from './sections/Hero';
 import Prizes from './sections/Prizes';
@@ -14,17 +14,10 @@ import PageTransition from './components/PageTransition';
 import OnboardingModal from './components/OnboardingModal';
 
 function Landing() {
-  const [isModalOpen, setModalOpen] = useState(false);
-  const MODAL_KEY = 'onboard_v1';
-
-  useEffect(() => {
-    try {
-      if (!localStorage.getItem(MODAL_KEY)) setModalOpen(true);
-    } catch {}
-  }, []);
-
+  const [isModalOpen, setModalOpen] = useState(true);
+  
+  
   const handleCloseModal = () => {
-    try { localStorage.setItem(MODAL_KEY, 'true'); } catch {}
     setModalOpen(false);
   };
 


### PR DESCRIPTION
## Purpose
The user requested to ensure the onboarding modal displays on page reload. This change removes the localStorage persistence mechanism so the modal will appear every time the page loads, rather than only on the first visit.

## Code changes
- Removed localStorage check and storage logic for the onboarding modal
- Changed initial modal state from `false` to `true` to always show on load
- Removed `useEffect` hook that was checking localStorage
- Simplified `handleCloseModal` function to only update state
- Removed unused `useEffect` importTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 17`

🔗 [Edit in Builder.io](https://builder.io/app/projects/da09819e1eed44a1a5f70e70323fbfce/nova-field)

👀 [Preview Link](https://da09819e1eed44a1a5f70e70323fbfce-nova-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>da09819e1eed44a1a5f70e70323fbfce</projectId>-->
<!--<branchName>nova-field</branchName>-->