### PR TITLE
Fix SSL config reference error in database connection

### DIFF
--- a/server.js
+++ b/server.js
@@ -15,6 +15,20 @@ const app = express();
 
 // Database pool (Render Postgres)
 const databaseUrl = process.env.DATABASE_URL || '';
+const sslConfig = (() => {
+  try {
+    if (process.env.DATABASE_SSL === 'true') return true;
+    if (process.env.DATABASE_SSL === 'false') return false;
+    if (!databaseUrl) return false;
+    const hasRequire = databaseUrl.includes('sslmode=require');
+    if (hasRequire || process.env.NODE_ENV === 'production') {
+      return { rejectUnauthorized: false };
+    }
+    return false;
+  } catch {
+    return false;
+  }
+})();
 let pool = null;
 if (databaseUrl) {
 


### PR DESCRIPTION
## Purpose
The application was failing to deploy on Render due to a `ReferenceError: sslConfig is not defined` error when attempting to establish a database connection. The user needed to resolve this deployment issue to get their Node.js application running successfully.

## Code changes
- Added proper `sslConfig` variable definition before it's used in the database Pool configuration
- Implemented dynamic SSL configuration logic that:
  - Checks `DATABASE_SSL` environment variable for explicit true/false values
  - Falls back to checking if database URL contains `sslmode=require`
  - Defaults to `{ rejectUnauthorized: false }` for production environments
  - Returns `false` for development or when no database URL is provided
- Wrapped configuration in try-catch block for error handlingTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 24`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ef2e121735754c44866c72e33aecb74a/aura-garden)

👀 [Preview Link](https://ef2e121735754c44866c72e33aecb74a-aura-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ef2e121735754c44866c72e33aecb74a</projectId>-->
<!--<branchName>aura-garden</branchName>-->