### PR TITLE
feat: Add admin tool for testing SMTP connection

### DIFF
--- a/server.js
+++ b/server.js
@@ -484,12 +484,33 @@ app.get('/smtp-verify', async (req, res) => {
     if (!adminToken || req.headers['x-admin-token'] !== adminToken) {
       return res.status(401).json({ ok: false, error: 'Unauthorized' });
     }
+
     const conf = getSmtpConfig();
-    if (!conf || !transport) return res.status(500).json({ ok: false, error: 'SMTP not configured' });
+    if (!conf || !transport) {
+      return res.status(400).json({ ok: false, error: 'SMTP is not configured on the server.' });
+    }
+
+    // The 'transport' object is already created and verified once on server start.
+    // We re-verify it here to provide an on-demand check.
     await transport.verify();
-    return res.json({ ok: true, host: conf.host, port: conf.port, secure: conf.secure });
+
+    // If verify() succeeds, the connection is valid.
+    return res.json({
+      ok: true,
+      message: 'SMTP connection verified successfully.',
+      host: conf.host,
+      port: conf.port,
+      secure: conf.secure,
+      user: conf.user,
+    });
+
   } catch (e) {
-    return res.status(500).json({ ok: false, error: e?.message || 'Verify failed' });
+    // If verify() fails, it throws an error.
+    return res.status(500).json({
+      ok: false,
+      error: 'SMTP verification failed.',
+      details: e?.message || 'No further details available.'
+    });
   }
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import LiveUpdates from './sections/LiveUpdates';
 import Footer from './sections/Footer';
 import Login from './sections/Login';
 import Dashboard from './sections/Dashboard';
+import SmtpTest from './sections/SmtpTest';
 import PageTransition from './components/PageTransition';
 import OnboardingModal from './components/OnboardingModal';
 
@@ -43,6 +44,7 @@ export default function App() {
       <Route path="/" element={<PageTransition><Landing /></PageTransition>} />
       <Route path="/login" element={<PageTransition><Login /></PageTransition>} />
       <Route path="/dashboard" element={<PageTransition><Dashboard /></PageTransition>} />
+      <Route path="/smtp-test" element={<PageTransition><SmtpTest /></PageTransition>} />
       <Route path="*" element={<PageTransition><Landing /></PageTransition>} />
     </Routes>
   );

--- a/src/sections/Dashboard.tsx
+++ b/src/sections/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { getMe, clearLocalSession, LedgerEntry, UserEntry } from '../utils/auth';
 import { useToast } from '../components/Toast';
 import WinnerWelcomeModal from '../components/WinnerWelcomeModal';
@@ -178,6 +179,15 @@ export default function Dashboard() {
                 <button className="button-primary" onClick={withdraw} disabled={bal.available <= 0}>Withdraw</button>
               </div>
             </div>
+
+            {localStorage.getItem('admin_token') && (
+              <div className="card card-pad mb-16">
+                <h3>Admin Tools</h3>
+                <ul className="ways-to-earn">
+                  <li><Link to="/smtp-test">SMTP Test Page</Link></li>
+                </ul>
+              </div>
+            )}
 
             {entry?.is_winner ? (
               <PrizeRoadmap user={entry} onDataRefresh={fetchDashboardData} />

--- a/src/sections/SmtpTest.tsx
+++ b/src/sections/SmtpTest.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+import { Button, Card, Typography, Spin, Alert } from 'antd';
+
+const SmtpTest: React.FC = () => {
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<any>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleTest = async () => {
+    setLoading(true);
+    setError(null);
+    setResult(null);
+
+    const adminToken = localStorage.getItem('admin_token');
+    if (!adminToken) {
+      setError('Admin token not found. Please set it in your browser local storage.');
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const response = await fetch('/smtp-verify', {
+        headers: {
+          'x-admin-token': adminToken,
+        },
+      });
+      const data = await response.json();
+      if (response.ok) {
+        setResult(data);
+      } else {
+        setError(data.error || 'An unknown error occurred.');
+      }
+    } catch (e: any) {
+      setError(e.message || 'Failed to fetch');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Card title="SMTP Connection Test">
+      <Typography.Paragraph>
+        Click the button below to verify the SMTP server connection. This will use the credentials configured on the server.
+      </Typography.Paragraph>
+      <Button type="primary" onClick={handleTest} disabled={loading}>
+        {loading ? <Spin /> : 'Run SMTP Test'}
+      </Button>
+      {result && (
+        <Alert
+          message="SMTP Connection Successful"
+          description={
+            <pre style={{ margin: 0 }}>
+              {JSON.stringify(result, null, 2)}
+            </pre>
+          }
+          type="success"
+          showIcon
+          style={{ marginTop: 16 }}
+        />
+      )}
+      {error && (
+        <Alert
+          message="SMTP Connection Failed"
+          description={error}
+          type="error"
+          showIcon
+          style={{ marginTop: 16 }}
+        />
+      )}
+    </Card>
+  );
+};
+
+export default SmtpTest;


### PR DESCRIPTION
This commit introduces a new feature that allows administrators to test the SMTP connection directly from the application's UI.

Key changes:
- Adds a new frontend page at `/smtp-test` with a UI to trigger an SMTP verification test.
- The page displays clear success or failure messages, including configuration details on success and error messages on failure.
- Adds a link to the new test page on the main dashboard, visible only when an admin token is present in local storage.
- Implements the backend logic for the `/smtp-verify` endpoint, which performs an on-demand check of the SMTP connection using `nodemailer`'s `verify()` method.