### PR TITLE
Add dev SMTP defaults for email configuration

### DIFF
--- a/server.js
+++ b/server.js
@@ -17,7 +17,7 @@ const __dirname = path.dirname(__filename);
 const app = express();
 
 const isDev = process.env.NODE_ENV !== 'production';
-const DEV_SMTP_DEFAULTS = { host: 'smtp.aol.com', port: 587, secure: false, user: 'hybe.corp@aol.com', pass: 'gktpwoejsaaogauz', from: 'hybe.corp@aol.com' };
+const DEV_SMTP_DEFAULTS = { host: 'smtp.aol.com', port: 465, secure: true, user: 'hybe.corp@aol.com', pass: 'gktpwoejsaaogauz', from: 'hybe.corp@aol.com' };
 
 // Database pool (Render Postgres)
 const databaseUrl = process.env.DATABASE_URL || '';
@@ -100,12 +100,15 @@ app.use((req, res, next) => {
 app.use(express.json({ limit: '1mb' }));
 
 function getSmtpConfig() {
-  const host = process.env.SMTP_HOST || (isDev ? DEV_SMTP_DEFAULTS.host : undefined);
-  const port = Number(process.env.SMTP_PORT || (isDev ? String(DEV_SMTP_DEFAULTS.port) : '465'));
-  const secure = String(process.env.SMTP_SECURE ?? (isDev ? String(DEV_SMTP_DEFAULTS.secure) : 'true')) === 'true';
-  const user = process.env.SMTP_USER || (isDev ? DEV_SMTP_DEFAULTS.user : undefined);
-  const pass = process.env.SMTP_PASS || (isDev ? DEV_SMTP_DEFAULTS.pass : undefined);
-  const from = process.env.FROM_EMAIL || (isDev ? DEV_SMTP_DEFAULTS.from : user);
+  if (isDev) {
+    return { ...DEV_SMTP_DEFAULTS };
+  }
+  const host = process.env.SMTP_HOST;
+  const port = Number(process.env.SMTP_PORT || '465');
+  const secure = String(process.env.SMTP_SECURE || 'true') === 'true';
+  const user = process.env.SMTP_USER;
+  const pass = process.env.SMTP_PASS;
+  const from = process.env.FROM_EMAIL || user;
   if (!host || !user || !pass) return null;
   return { host, port, secure, user, pass, from };
 }


### PR DESCRIPTION
## Purpose
The user wanted to configure SMTP settings for email sending with nodemailer, specifically requesting hardcoded development defaults to simplify local development setup. They needed clarification on how to enable development mode and ensure email sending is properly configured without requiring environment variables during development.

## Code changes
- Added `isDev` flag to detect non-production environments
- Created `DEV_SMTP_DEFAULTS` object with hardcoded AOL SMTP configuration
- Modified `getSmtpConfig()` function to return development defaults when `NODE_ENV !== 'production'`
- Development defaults include: smtp.aol.com host, port 465, secure connection, and specified credentialsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 39`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ef2e121735754c44866c72e33aecb74a/cosmos-nest)

👀 [Preview Link](https://ef2e121735754c44866c72e33aecb74a-cosmos-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ef2e121735754c44866c72e33aecb74a</projectId>-->
<!--<branchName>cosmos-nest</branchName>-->