### PR TITLE
fix: Add Netlify redirect rule for SPA routing

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,7 @@
 [functions]
   directory = "netlify/functions/"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
This commit adds a redirect rule to the `netlify.toml` file to correctly handle routing for the single-page application (SPA).

The rule `[[redirects]] from = "/*" to = "/index.html" status = 200` ensures that any direct navigation or page refresh is routed to the `index.html` file, allowing the React Router to take over and manage the application's routes correctly. This fixes the 'Page Not Found' errors that occur on refresh.