### PR TITLE
fix: Exclude test files from Netlify functions deployment

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,6 @@
 [functions]
   directory = "netlify/functions/"
+  included_files = ["!**/*.test.js"]
 
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
The Netlify deployment was failing because it was attempting to deploy test files (e.g., `send-otp.test.js`) as serverless functions. Test files are not valid functions and their names, which contain dots, are not allowed by Netlify.

This change updates the `netlify.toml` configuration to explicitly exclude any files ending in `.test.js` from the functions deployment. This ensures that only valid function files are deployed, resolving the deployment error.