### PR TITLE
Fix Supabase config for auth email delivery issues

### DIFF
--- a/netlify/functions/utils/supabase.js
+++ b/netlify/functions/utils/supabase.js
@@ -1,12 +1,24 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.SUPABASE_DATABASE_URL;
-const supabaseKey = process.env.SUPABASE_ANON_KEY;
+// Prefer standard server environment variable names first, then fallbacks.
+const supabaseUrl =
+  process.env.SUPABASE_URL ||
+  process.env.VITE_SUPABASE_URL ||
+  process.env.SUPABASE_DATABASE_URL ||
+  '';
+
+const supabaseKey =
+  process.env.SUPABASE_ANON_KEY ||
+  process.env.VITE_SUPABASE_ANON_KEY ||
+  process.env.SUPABASE_SERVICE_ROLE_KEY ||
+  '';
 
 if (!supabaseUrl || !supabaseKey) {
-  throw new Error('Supabase URL and Anon Key must be provided.');
+  throw new Error(
+    'Missing Supabase configuration. Please set SUPABASE_URL and SUPABASE_ANON_KEY in your environment.'
+  );
 }
 
-const supabase = createClient(supabaseUrl, supabaseKey);
+const supabase = createClient(supabaseUrl, supabaseKey, { auth: { persistSession: false } });
 
 export default supabase;


### PR DESCRIPTION
## Purpose
Users reported that authentication emails (verification codes and OTP) are not being delivered. The "SEND VERIFICATION CODE" button changes to "SENDING..." but returns to normal state without sending emails, and login attempts fail with "failed to send OTP" messages. This fix addresses potential configuration issues in the Supabase client setup that could be preventing email delivery.

## Code changes
- **Enhanced environment variable fallback chain**: Added multiple fallback options for Supabase URL and API key configuration to handle different deployment environments
- **Improved error messaging**: Updated error message to be more descriptive about missing configuration requirements
- **Added session persistence configuration**: Set `persistSession: false` in Supabase client options for serverless function compatibility
- **Better environment variable naming**: Added support for standard `SUPABASE_URL` and fallback to `VITE_SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` as alternativesTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 59`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ec5f9d00b7af4a7f8f084d670908e7a2/swoosh-studio)

👀 [Preview Link](https://ec5f9d00b7af4a7f8f084d670908e7a2-swoosh-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ec5f9d00b7af4a7f8f084d670908e7a2</projectId>-->
<!--<branchName>swoosh-studio</branchName>-->