### PR TITLE
fix: Correct type guard for VerifyOtpResponse

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -79,7 +79,7 @@ export async function loginWithPassword(email: string, password: string): Promis
   const res = await tryFetch(endpoint, { method: 'POST', headers: buildHeaders(), body: JSON.stringify({ email, password }) });
   const data = await parseJsonOrThrow(res as any, 'Login failed');
   const typed = data as VerifyOtpResponse;
-  if (!('ok' in data) || !data.ok) throw new Error((data && data.error) || 'Login failed');
+  if (!typed.ok) throw new Error(typed.error || 'Login failed');
   return typed.session.access_token;
 }
 


### PR DESCRIPTION
The `loginWithPassword` function had an incorrect type guard that was causing a TypeScript error. This change updates the type guard to correctly narrow the `VerifyOtpResponse` discriminated union, aligning it with the pattern used in the `verifyOtp` function. This resolves the build failure.