### PR TITLE
This commit resolves a Netlify build failure caused by an exposed sec…

### DIFF
--- a/src/pages/EntryFormPage.tsx
+++ b/src/pages/EntryFormPage.tsx
@@ -78,7 +78,7 @@ const EntryFormPage = () => {
     setSubmissionStatus(null);
     setSubmissionMessage('');
     try {
-      const response = await fetch('https://formspree.io/f/myznwdan', {
+      const response = await fetch(import.meta.env.VITE_FORMSPREE_URL, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
…ret.

The hardcoded Formspree URL in `EntryFormPage.tsx` has been replaced with the `VITE_FORMSPREE_URL` environment variable. This prevents the secret from being exposed in the build output and aligns with best practices for managing sensitive information.