### PR TITLE
This commit resolves a Netlify build failure caused by an exposed sec…

### DIFF
--- a/netlify/functions/submit-to-formspree.js
+++ b/netlify/functions/submit-to-formspree.js
@@ -1,0 +1,47 @@
+export const handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return {
+      statusCode: 405,
+      body: JSON.stringify({ message: 'Method Not Allowed' }),
+    };
+  }
+
+  const { FORMSPREE_URL } = process.env;
+  if (!FORMSPREE_URL) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ message: 'Formspree URL not configured.' }),
+    };
+  }
+
+  try {
+    const response = await fetch(FORMSPREE_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      },
+      body: event.body,
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return {
+        statusCode: response.status,
+        body: JSON.stringify(data),
+      };
+    }
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify(data),
+    };
+  } catch (error) {
+    console.error('Error submitting to Formspree:', error);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ message: 'An internal server error occurred.' }),
+    };
+  }
+};

--- a/src/pages/EntryFormPage.tsx
+++ b/src/pages/EntryFormPage.tsx
@@ -78,7 +78,7 @@ const EntryFormPage = () => {
     setSubmissionStatus(null);
     setSubmissionMessage('');
     try {
-      const response = await fetch(import.meta.env.VITE_FORMSPREE_URL, {
+      const response = await fetch('/.netlify/functions/submit-to-formspree', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
…ret in the build output.

A Netlify function has been created at `netlify/functions/submit-to-formspree.js` to act as a secure proxy for Formspree submissions. The frontend form in `EntryFormPage.tsx` now sends its data to this function, which then forwards the request to the Formspree URL stored in a server-side environment variable (`FORMSPREE_URL`).

This change prevents the Formspree URL from being exposed in the client-side code, resolving the secret scanning issue and adhering to security best practices.