### PR TITLE
feat: Implement referral code system

### DIFF
--- a/netlify/functions/post-entry.js
+++ b/netlify/functions/post-entry.js
@@ -70,6 +70,20 @@ const handler = async (event) => {
       return { statusCode: 409, body: JSON.stringify({ ok: false, error: 'Entry already exists for this email' }) };
     }
 
+    // Validate referral code
+    const validReferralCode = '#BTS2026';
+    let welcomeBonus = 100;
+    let bonusNote = 'Welcome bonus';
+
+    if (referral_code) {
+      if (referral_code === validReferralCode) {
+        welcomeBonus = 200;
+        bonusNote = 'Welcome bonus (with valid referral code)';
+      } else {
+        return { statusCode: 400, body: JSON.stringify({ ok: false, error: 'Invalid referral code' }) };
+      }
+    }
+
     // Insert new entry
     const payload = {
       email,
@@ -101,9 +115,9 @@ const handler = async (event) => {
     const { error: ledgerError } = await supabase.from('ledger_entries').insert({
       email,
       type: 'credit',
-      amount: 100,
+      amount: welcomeBonus,
       currency: 'points',
-      note: 'Welcome bonus',
+      note: bonusNote,
       status: 'available'
     });
     if (ledgerError) console.error('Ledger bonus failed', ledgerError);

--- a/src/pages/EntryFormPage.tsx
+++ b/src/pages/EntryFormPage.tsx
@@ -81,8 +81,8 @@ const EntryFormPage: React.FC = () => {
             <fieldset className="border p-3 h-100">
               <legend className="w-auto h5">Personal Information</legend>
               <div className="mb-3">
-                <label htmlFor="referral-code" className="form-label">Referral Code <span className="text-danger">*</span></label>
-                <input type="text" id="referral-code" className={`form-control ${errors.referralCode ? 'is-invalid' : ''}`} {...register("referralCode", { required: "Referral code is required." })} />
+                <label htmlFor="referral-code" className="form-label">Referral Code</label>
+                <input type="text" id="referral-code" className={`form-control ${errors.referralCode ? 'is-invalid' : ''}`} {...register("referralCode")} placeholder="(Optional)" />
                 {errors.referralCode && <div className="invalid-feedback">{errors.referralCode.message}</div>}
               </div>
               <div className="mb-3">


### PR DESCRIPTION
Implements a new referral code system for the giveaway entry form.

- The `referralCode` field on the frontend is now optional.
- The backend validates the provided code.
- If the code is '#BTS2026', the user receives a 200-point bonus.
- If an incorrect code is entered, an error is returned.
- If no code is entered, the user receives the standard 100-point welcome bonus.