### PR TITLE
fix(routing): Use react-router-dom for SPA navigation

### DIFF
--- a/netlify/netlify/package-lock.json
+++ b/netlify/netlify/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "netlify",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { Routes, Route, useLocation } from 'react-router-dom';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Navbar from './sections/Navbar';
 import Hero from './sections/Hero';
 import Prizes from './sections/Prizes';
@@ -16,6 +16,18 @@ import EntryFormPage from './pages/EntryFormPage';
 
 function Landing() {
   const [showOnboard, setShowOnboard] = useState(true);
+  const location = useLocation();
+
+  useEffect(() => {
+    const { state } = location;
+    if (state?.scrollTo) {
+      const el = document.getElementById(state.scrollTo);
+      if (el) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    }
+  }, [location]);
+
   return (
     <>
       <OnboardingModal isOpen={showOnboard} onClose={() => setShowOnboard(false)} />

--- a/src/sections/Navbar.tsx
+++ b/src/sections/Navbar.tsx
@@ -1,12 +1,18 @@
 import { useState } from 'react';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 
 export default function Navbar() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const navigate = useNavigate();
+  const location = useLocation();
 
-  const go = (id: string) => {
-    const el = document.getElementById(id);
-    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    setIsMenuOpen(false); // Close menu on link click
+  const handleScroll = (id: string) => {
+    setIsMenuOpen(false);
+    if (location.pathname !== '/') {
+      navigate('/', { state: { scrollTo: id } });
+    } else {
+      document.getElementById(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
   };
 
   const toggleMenu = () => {
@@ -25,11 +31,11 @@ export default function Navbar() {
           <div className="bar"></div>
         </div>
         <nav className={`nav-links ${isMenuOpen ? 'open' : ''}`}>
-          <button className="nav-button" onClick={() => go('prizes')}>Prizes</button>
-          <button className="nav-button" onClick={() => go('vip')}>VIP Experience</button>
-          <button className="nav-button" onClick={() => go('enter')}>Enter Now</button>
-          <button className="nav-button" onClick={() => go('updates')}>Live Updates</button>
-          <a className="nav-button" href="/dashboard">Dashboard</a>
+          <button className="nav-button" onClick={() => handleScroll('prizes')}>Prizes</button>
+          <button className="nav-button" onClick={() => handleScroll('vip')}>VIP Experience</button>
+          <button className="nav-button" onClick={() => handleScroll('enter')}>Enter Now</button>
+          <button className="nav-button" onClick={() => handleScroll('updates')}>Live Updates</button>
+          <Link className="nav-button" to="/dashboard">Dashboard</Link>
         </nav>
       </div>
     </header>


### PR DESCRIPTION
Replaced standard `<a>` tags and `scrollIntoView` with `react-router-dom`'s `Link` and `useNavigate` components in the Navbar. This resolves redirect errors and broken navigation on the Netlify-deployed site by ensuring all navigation is handled client-side, consistent with the single-page application architecture.

The `handleScroll` function now correctly navigates to the home page from other pages before scrolling to the target section, and a `useEffect` hook in `App.tsx` manages the scroll behavior upon navigation.