### PR TITLE
Add configurable function URLs for Netlify functions

### DIFF
--- a/src/components/RouteLoader.tsx
+++ b/src/components/RouteLoader.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import { getFunctionUrl } from '../utils/functionsApi';
 
 export default function RouteLoader() {
   const location = useLocation();
@@ -52,7 +53,9 @@ export default function RouteLoader() {
     const tryPing = async (): Promise<boolean> => {
       const ts = Date.now();
       const cacheBuster = `cb=${ts}`;
+      const fnGetEvents = getFunctionUrl('get-events');
       const candidates = [
+        `${fnGetEvents}?${cacheBuster}`,
         `/.netlify/functions/get-events?${cacheBuster}`,
         `/manifest.webmanifest?${cacheBuster}`,
         `/hybe-logo.svg?${cacheBuster}`,

--- a/src/pages/EntryFormPage.tsx
+++ b/src/pages/EntryFormPage.tsx
@@ -5,6 +5,7 @@ import 'react-phone-number-input/style.css';
 import '../styles/EntryForm.css';
 import Navbar from '../sections/Navbar';
 import Footer from '../sections/Footer';
+import { getFunctionUrl } from '../utils/functionsApi';
 
 // HYBE hierarchy: Branch -> Group -> Artists
 const HYBE_STRUCTURE: Record<string, { label: string; groups: Record<string, { label: string; artists: string[] }> }> = {
@@ -276,8 +277,8 @@ const EntryFormPage: React.FC = () => {
 
   async function submitEntryToNetlify(payload: Record<string, any>) {
     try {
-      // Try direct serverless function first (works in dev and on Netlify)
-      const apiRes = await safeFetch('/.netlify/functions/submit-entry', {
+      const submitUrl = getFunctionUrl('submit-entry');
+      const apiRes = await safeFetch(submitUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
@@ -287,7 +288,6 @@ const EntryFormPage: React.FC = () => {
         return;
       }
 
-      // Fallback to Netlify Forms (requires Netlify hosting)
       const body = toUrlEncoded({ 'form-name': 'entry', ...payload });
       const formRes = await safeFetch('/', {
         method: 'POST',

--- a/src/utils/functionsApi.ts
+++ b/src/utils/functionsApi.ts
@@ -1,0 +1,18 @@
+export function getFunctionUrl(name: string): string {
+  const env = (import.meta as any).env || {};
+  const normalized = String(name).trim().replace(/^\/+|\/+$/g, '');
+  const key = `VITE_FN_${normalized.replace(/[^a-z0-9]/gi, '_').toUpperCase()}_URL`;
+  const specific = env[key];
+  if (specific && typeof specific === 'string' && specific.trim()) {
+    return specific.trim();
+  }
+  const base = (env.VITE_FUNCTIONS_BASE_URL as string) || (env.VITE_FUNCTIONS_BASE as string) || '/.netlify/functions';
+  const trimmedBase = String(base || '').trim().replace(/\/+$/g, '');
+  if (!trimmedBase) return `/.netlify/functions/${normalized}`;
+  // If base looks like absolute URL, join with a single slash
+  if (/^https?:\/\//i.test(trimmedBase)) {
+    return `${trimmedBase}/${normalized}`;
+  }
+  // Relative base path (e.g. '/.netlify/functions')
+  return `${trimmedBase}/${normalized}`;
+}


### PR DESCRIPTION
## Purpose

The user was investigating a "Form submit failed. Please try again." error and provided specific Netlify function URLs that needed to be configured. This change addresses the need to make function URLs configurable through environment variables to support different deployment environments and resolve submission failures.

## Code changes

- **Added `functionsApi.ts` utility**: Created a new utility function `getFunctionUrl()` that dynamically constructs function URLs based on environment variables
- **Updated EntryFormPage**: Modified form submission to use the configurable URL system instead of hardcoded paths
- **Updated RouteLoader**: Enhanced ping functionality to include configurable function URLs for better connectivity testing
- **Environment variable support**: Added support for `VITE_FUNCTIONS_BASE_URL` and function-specific URL overrides (e.g., `VITE_FN_SUBMIT_ENTRY_URL`)

The changes enable flexible function URL configuration across different environments while maintaining backward compatibility with default Netlify function paths.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 124`

🔗 [Edit in Builder.io](https://builder.io/app/projects/486063a218b94be19c39b9fb9fa358cd/mystic-haven)

👀 [Preview Link](https://486063a218b94be19c39b9fb9fa358cd-mystic-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>486063a218b94be19c39b9fb9fa358cd</projectId>-->
<!--<branchName>mystic-haven</branchName>-->